### PR TITLE
changes to the actionInstruction xsd

### DIFF
--- a/src/main/resources/xsd/actionInstruction.xsd
+++ b/src/main/resources/xsd/actionInstruction.xsd
@@ -36,6 +36,10 @@
     <!-- a complex type for addresses - no statistical geography info -->
     <xs:complexType name="ActionAddress">
         <xs:sequence>
+            <xs:element name="arid" type="xs:string" minOccurs="0"
+                        maxOccurs="1"/>
+            <xs:element name="uprn" type="xs:string" minOccurs="0"
+                        maxOccurs="1"/>
             <xs:element name="type" type="xs:string" minOccurs="0"
                         maxOccurs="1"/>
             <xs:element name="estabType" type="xs:string" minOccurs="0"
@@ -64,6 +68,8 @@
                         maxOccurs="1"/>
             <xs:element name="longitude" type="xs:decimal" minOccurs="0"
                         maxOccurs="1"/>
+            <xs:element name="oa" type="xs:string" minOccurs="0"
+                        maxOccurs="1"/>
         </xs:sequence>
     </xs:complexType>
 
@@ -77,6 +83,7 @@
                     <xs:element name="questionSet" type="xs:string" minOccurs="0" maxOccurs="1"/>
                     <xs:element name="contact" type="ActionContact" minOccurs="0" maxOccurs="1"/>
                     <xs:element name="address" type="ActionAddress" minOccurs="0"/>
+                    <xs:element name="pause" type="ActionPause" minOccurs="0" maxOccurs="1"/>
                     <xs:element name="legalBasis" type="xs:string" minOccurs="0" maxOccurs="1"/>
                     <xs:element name="region" type="xs:string" minOccurs="0" maxOccurs="1"/>
                     <xs:element name="respondentStatus" type="xs:string" minOccurs="0" maxOccurs="1"/>
@@ -93,9 +100,35 @@
                     <xs:element name="surveyRef" type="xs:string" minOccurs="0" maxOccurs="1"/>
                     <xs:element name="returnByDate" type="xs:string" minOccurs="0" maxOccurs="1"/>
                     <xs:element name="sampleUnitRef" type="xs:string" minOccurs="1" maxOccurs="1"/>
+
+
+                    <xs:element name="addressType" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="addressLevel" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="treatmentId" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="fieldOfficerId" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="coordinatorId" type="xs:string" minOccurs="0" maxOccurs="1"/>
+
+                    <xs:element name="undeliveredAsAddress" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="blankQreReturned" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+
+                    <xs:element name="ccsQuestionnaireUrl" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="ceDeliveryReqd" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="ceCE1Complete" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="ceExpectedResponses" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="ceActualResponses" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="ActionPause">
+        <xs:sequence>
+            <xs:element name="effectiveDate" type="xs:date" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="code" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="reason" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="holdUntil" type="xs:date" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
     </xs:complexType>
 
     <!-- a complex and reused type constraining the priority element -->
@@ -113,8 +146,7 @@
     <!-- a complex type for containing multiple action event elements -->
     <xs:complexType name="ActionEvent">
         <xs:sequence>
-            <xs:element name="event" type="xs:string" minOccurs="0"
-                        maxOccurs="unbounded"/>
+            <xs:element name="event" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
 


### PR DESCRIPTION
# Motivation and Context
In order to send a create case message to Totalmobile Comet for Household we had to send Comet some additional details which were not originally part of ActionInstruction.xsd. Using a data map provided by Dave Richards outlining fields from the sample that are required by Comet to create Household jobs we made changes to our system. 

# What has changed
Changes to the ActionInstruction.xsd to include fields required to create Household jobs in Comet. A copy of the data map will be linked below.

# How to test?
We run a mvn clean install locally for census-rm-action-service with the new XSD.

# Links
https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?pageId=17468820
https://collaborate2.ons.gov.uk/jira/browse/FWMT-984
