### PR TITLE
Add ActionType for initial contact letter wales.

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/action/representation/ActionType.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/representation/ActionType.java
@@ -13,7 +13,8 @@ public enum ActionType {
   SOCIALSNE("SOCIALSNE"),
   SOCIALPRENOT("SOCIALPRENOT"),
   SOCIALICF("SOCIALICF"),
-  ICL1E("ICL1E");
+  ICL1E("ICL1E"),
+  ICL2E("ICL2E");
 
   private String name;
 

--- a/src/main/resources/database/changelog-master.yml
+++ b/src/main/resources/database/changelog-master.yml
@@ -53,3 +53,6 @@ databaseChangeLog:
 
 - include:
     file: database/changes/census-release-1/changelog.yml
+
+- include:
+    file: database/changes/census-release-2/changelog.yml

--- a/src/main/resources/database/changes/census-release-2/add_action_type_census_initial_contact_letter_wales.sql
+++ b/src/main/resources/database/changes/census-release-2/add_action_type_census_initial_contact_letter_wales.sql
@@ -1,0 +1,4 @@
+INSERT INTO action.actiontype
+(actiontypepk, name, description, handler, cancancel, responserequired)
+VALUES
+(14, 'ICL2E', 'Census initial contact letter for Wales', 'Printer', true, false);

--- a/src/main/resources/database/changes/census-release-2/changelog.yml
+++ b/src/main/resources/database/changes/census-release-2/changelog.yml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+
+  - changeSet:
+      id: 1-0
+      author: Richard Weeks
+      changes:
+        - sqlFile:
+            comment: Add an action type for census initial contact letters for wales (ICL2)
+            path: add_action_type_census_initial_contact_letter_wales.sql
+            relativeToChangelogFile: true
+            splitStatements: false


### PR DESCRIPTION
# Motivation and Context
This change creates the Action Type for the initial contact letter for Wales.

# What has changed
Liquibase script has been added.

# How to test?
Build new Docker image and run, check new row is created in actiontype table.
# Links
https://trello.com/c/oRPSTwHn/594-rmc-119-action-exporter-service-to-generate-initial-contact-letter-print-file-wales-5
